### PR TITLE
Make skin tone menu tabbable

### DIFF
--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -4,11 +4,14 @@ type Props = Readonly<{
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  tabIndex?: number;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }>;
 
-export default function Relative({ children, className, style }: Props) {
+export default function Relative({ children, className, style, tabIndex, onKeyDown }: Props) {
   return (
-    <div style={{ ...style, position: 'relative' }} className={className}>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div style={{ ...style, position: 'relative' }} className={className} tabIndex={tabIndex} onKeyDown={onKeyDown}>
       {children}
     </div>
   );

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -8,6 +8,7 @@ import skinToneVariations, {
 } from '../../data/skinToneVariations';
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import { useFocusSearchInput } from '../../hooks/useFocus';
+import { KeyboardEvents } from '../../hooks/useKeyboardNavigation';
 import { SkinTones } from '../../types/exposedTypes';
 import Absolute from '../Layout/Absolute';
 import Relative from '../Layout/Relative';
@@ -65,8 +66,18 @@ export function SkinTonePicker({
           ? { flexBasis: expandedSize, height: expandedSize }
           : { flexBasis: expandedSize }
       }
+      tabIndex={0}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        const { key } = event;
+        if (key === KeyboardEvents.Enter) {
+          if (!isOpen) {
+            setIsOpen(true)
+          }
+          closeAllOpenToggles();
+        }
+      }}
     >
-      <div className="epr-skin-tone-select" ref={SkinTonePickerRef}>
+      <div className="epr-skin-tone-select" ref={SkinTonePickerRef} >
         {skinToneVariations.map((skinToneVariation, i) => {
           const active = skinToneVariation === activeSkinTone;
           return (
@@ -88,15 +99,27 @@ export function SkinTonePicker({
                 }
                 closeAllOpenToggles();
               }}
+              // when tabbed onto the SkinTonePicker, allow Enter to open and close the fan of colors
+              onKeyDown={(event) => {
+                const { key } = event;
+                if (key === KeyboardEvents.Enter) {
+                  if (isOpen) {
+                    setActiveSkinTone(skinToneVariation);
+                    focusSearchInput();
+                  } else {
+                    setIsOpen(true);
+                  }
+                  closeAllOpenToggles();
+                }
+              }}
+              tabIndex={isOpen ? 0 : -1}
               key={skinToneVariation}
               className={clsx(`epr-tone-${skinToneVariation}`, 'epr-tone', {
                 [ClassNames.active]: active
               })}
-              tabIndex={isOpen ? 0 : -1}
               aria-pressed={active}
-              aria-label={`Skin tone ${
-                skinTonesNamed[skinToneVariation as SkinTones]
-              }`}
+              aria-label={`Skin tone ${skinTonesNamed[skinToneVariation as SkinTones]
+                }`}
             ></Button>
           );
         })}

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -43,7 +43,7 @@ import {
   useIsSkinToneInSearch
 } from './useShouldShowSkinTonePicker';
 
-enum KeyboardEvents {
+export enum KeyboardEvents {
   ArrowDown = 'ArrowDown',
   ArrowUp = 'ArrowUp',
   ArrowLeft = 'ArrowLeft',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ export {
   SkinTonePickerLocation
 } from './types/exposedTypes';
 
-export interface Props extends PickerConfig {}
+export interface Props extends PickerConfig { }
 
 export default function EmojiPicker(props: Props) {
   return (


### PR DESCRIPTION
In this PR, we add onKeyDown and tabIndex props to components within the SkinTonePicker to enable a user to open and close the menu on "Enter", "Tab" through the options, and "Enter" to select a new skin tone and close the menu.

https://user-images.githubusercontent.com/22733487/211424301-5c397c14-9021-4f19-83a6-3639d7c2e999.mov

