### PR TITLE
Enable skin tone selection persistence via keyboard actions

### DIFF
--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -107,6 +107,7 @@ export function SkinTonePicker({
                 if (key === KeyboardEvents.Enter) {
                   if (isOpen) {
                     setActiveSkinTone(skinToneVariation);
+                    setSkinTone(skinToneVariation)
                     focusSearchInput();
                   } else {
                     setIsOpen(true);


### PR DESCRIPTION
Whoops, missed this. On Enter, we need to save skin tone selection to localStorage just as we do on click.