### PR TITLE
Escape should close emoji picker, not entire webchat window

### DIFF
--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -84,11 +84,13 @@ function usePickerMainKeyboardEvents() {
             event.preventDefault();
             if (hasOpenToggles()) {
               closeAllOpenToggles();
+              event.stopPropagation()
               return;
             }
             clearSearch();
             scrollTo(0);
             focusSearchInput();
+            event.stopPropagation()
             break;
         }
       },


### PR DESCRIPTION
Testing this out to see if it works.