### PR TITLE
Undo change to Escape behavior

### DIFF
--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -84,13 +84,11 @@ function usePickerMainKeyboardEvents() {
             event.preventDefault();
             if (hasOpenToggles()) {
               closeAllOpenToggles();
-              event.stopPropagation()
               return;
             }
             clearSearch();
             scrollTo(0);
             focusSearchInput();
-            event.stopPropagation()
             break;
         }
       },


### PR DESCRIPTION
`event.stopPropogation()` did not work. Let's undo this change and do this differently.