### PR TITLE
Changes post accessibility review

### DIFF
--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -87,7 +87,10 @@ export function SkinTonePicker({
                 transform: clsx(
                   vertical
                     ? `translateY(-${i * (isOpen ? ITEM_SIZE : 0)}px)`
-                    : `translateX(-${i * (isOpen ? ITEM_SIZE : 0)}px)`,
+                    // library fans out colors to the left of the selected one
+                    // it was requested that the selected one should move left and the rest of the colors should fan out to the right
+                    // to aid with tab-accessibility
+                    : `translateX(${(i * (isOpen ? ITEM_SIZE : 0)) - (isOpen ? ((skinToneVariations.length - 1) * ITEM_SIZE) : 0)}px)`,
                   isOpen && active && 'scale(1.3)'
                 )
               }}

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -81,14 +81,16 @@ function usePickerMainKeyboardEvents() {
         switch (key) {
           // eslint-disable-next-line no-fallthrough
           case KeyboardEvents.Escape:
-            event.preventDefault();
+            // event.preventDefault()
             if (hasOpenToggles()) {
               closeAllOpenToggles();
+              event.stopPropagation()
               return;
             }
             clearSearch();
             scrollTo(0);
             focusSearchInput();
+            event.stopPropagation()
             break;
         }
       },


### PR DESCRIPTION
By default, when a user expands the skin-tone picker, the selected tone remains in-place, and the other colors fan out to the left. The tab focus remains on the selected tone, so the tabbability of the picker is broken. The user is tabbed onto the last item and has to go backwards to select a different tone. 

In this PR, I change the direction to move the selected tone to the left and fan out the other tones to the right to fix the tabbability.

The other change is another attempt to fix the behavior of ESC.